### PR TITLE
Correction of quality check bugs

### DIFF
--- a/OBSrange_MATLAB/functions/pingQC.m
+++ b/OBSrange_MATLAB/functions/pingQC.m
@@ -41,7 +41,7 @@ alt = data.alt;
 x_drop=0;
 y_drop=0;
 
-twt_pre = calcTWT(x_drop, y_drop, z_drop, 0, 0, x_ship, y_ship, 0, vp_w);
+twt_pre = calcTWT(x_drop, y_drop, z_drop, 0, par.TAT, x_ship, y_ship, 0, vp_w);
 dtwt = twt - twt_pre;
 
 I_bad = abs(dtwt)*1000 > res_thresh | alt' < 0;

--- a/OBSrange_PYTHON/funcs/locate.py
+++ b/OBSrange_PYTHON/funcs/locate.py
@@ -45,9 +45,13 @@ def instruments(datafile, parameters, ssp_dir):
   # Perform quality control on loaded data.
   if QC:
     print('\n Performing quality control ...')
-    data, data_bad = pings.qc(data, vpw0, thresh=res_thresh)
+    data, data_bad = pings.qc(data, vpw0, tat, thresh=res_thresh)
     N_badpings = len(data_bad['twts'])
     print(' Number of pings removed: ' + str(N_badpings))
+  else:
+    # QC disabled, use a ridiculously high threshold to avoid removing any ping
+    data, data_bad = pings.qc(data, vpw0, tat, thresh=999999)
+    N_badpings = len(data_bad['twts'])
   
   ##################### Intermediate Variable Declarations #####################
   

--- a/OBSrange_PYTHON/funcs/pings.py
+++ b/OBSrange_PYTHON/funcs/pings.py
@@ -103,7 +103,7 @@ def load(txt_file):
           
   return data
 
-def qc(data, vpw, thresh):
+def qc(data, vpw, tat, thresh):
   # Grab required variables to calculate time to traverse the Euclidean dist.
   lat0 = data['lat_drop']
   lon0 = data['lon_drop']
@@ -116,7 +116,7 @@ def qc(data, vpw, thresh):
   xs, ys = coord_txs.latlon2xy(lat0, lon0, lats, lons)
  
   # Calculate theoretical two-way travel-times and residuals.
-  theor_twts = calc.twt(x0=0,y0=0,z0=z0,xs=xs,ys=ys,zs=0,vpw=vpw,dvp=0,tat=0)
+  theor_twts = calc.twt(x0=0,y0=0,z0=z0,xs=xs,ys=ys,zs=0,vpw=vpw,dvp=0,tat=tat)
   dtwts = twts - theor_twts
 
   # Find which survey points exceed the time threshold (units msecs).


### PR DESCRIPTION
This PR corrects two bugs in the Python version that were identified when using the code with instruments having a big turn around time (`tat` variable with a value of approximately 4s).

- Turn around time was not used during QC, rejecting all the pings. I just added it to the variables passed to the QC function so that the value can be used (instead of assuming 0 turn around time)

- Code was failing if QC was disabled because the `data_bad` structure and the `N_badpings` variable were not initialized. I call the QC function with a very very high threshold to avoid removing any ping and to initialize all the variables.


Missing `par.TAT` in pings quality check was also corrected for Matlab version but not tested.